### PR TITLE
feat: expose a setFetchFaviconTimeout function

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -16,7 +16,11 @@ function getFavicons (url) {
   }])
 }
 
-export { fetchFavicon as default }
+function setFetchFaviconTimeout (ms) {
+  return x.timeout(ms)
+}
+
+export { fetchFavicon as default, setFetchFaviconTimeout }
 
 export
 function fetchFavicon (url, size) {


### PR DESCRIPTION
Hi,

I need to set a timeout for my fetch requests, so I just expose a `setFetchFaviconTimeout` function.

Maybe it can be a good thing to expose the x-ray instance instead ?